### PR TITLE
Move token and ref to option object

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ $ npm install list-github-dir-content
 ```js
 const listContent = require('list-github-dir-content');
 
-const myToken = '000'; // https://github.com/settings/tokens
+const options = {
+  ref: 'master',
+  token: '' // Empty token disable auth
+};
 
 // They have the same output
-const filesArray = await listContent.viaTreesApi('Microsoft/vscode', 'src', myToken);
+const filesArray = await listContent.viaTreesApi('Microsoft/vscode', 'src', options);
 // OR
-const filesArray = await listContent.viaContentsApi('Microsoft/vscode', 'src', myToken);
+const filesArray = await listContent.viaContentsApi('Microsoft/vscode', 'src', options);
 
 // ['src/file.js', 'src/styles/main.css', ...]
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Both methods return a Promise that resolves with an array of all the files in th
 
 **Notice:** while they work differently, they have the same output if no limit was reached.
 
-Known issues: 
+Known issues:
 
 - `viaContentsApi` is limited to 1000 files _per directory_
 - `viaTreesApi` is limited to around 60,000 files _per repo_
@@ -67,8 +67,13 @@ Type: `string`
 
 A GitHub personal token, get one here: https://github.com/settings/tokens
 
+#### ref
+
+Type: `string`
+
+The name of the commit/branch/tag, default to `master`
+
 
 ## License
 
 MIT © [Federico Brigante](http://twitter.com/bfred_it)
-

--- a/index.js
+++ b/index.js
@@ -1,17 +1,19 @@
 const fetch = require('node-fetch'); // Automatically excluded in browser bundles
 
+const defaultRef = 'master';
+
 // Great for downloads with few sub directories on big repos
 // Cons: many requests if the repo has a lot of nested dirs
-async function viaContentsApi(repo, dir, token) {
+async function viaContentsApi(repo, dir, token, ref = defaultRef) {
 	const files = [];
 	const requests = [];
-	const response = await fetch(`https://api.github.com/repos/${repo}/contents/${dir}?access_token=${token}`);
+	const response = await fetch(`https://api.github.com/repos/${repo}/contents/${dir}?access_token=${token}&ref=${ref}`);
 	const contents = await response.json();
 	for (const item of contents) {
 		if (item.type === 'file') {
 			files.push(item.path);
 		} else if (item.type === 'dir') {
-			requests.push(viaContentsApi(repo, item.path, token));
+			requests.push(viaContentsApi(repo, item.path, token, ref));
 		}
 	}
 	return files.concat(...await Promise.all(requests));
@@ -20,9 +22,9 @@ async function viaContentsApi(repo, dir, token) {
 // Great for downloads with many sub directories
 // Pros: one request + maybe doesn't require token
 // Cons: huge on huge repos + may be truncated and has to fallback to viaContentsApi
-async function viaTreesApi(repo, dir, token) {
+async function viaTreesApi(repo, dir, token, ref = defaultRef) {
 	const files = [];
-	const response = await fetch(`https://api.github.com/repos/${repo}/git/trees/master?recursive=1&access_token=${token}`);
+	const response = await fetch(`https://api.github.com/repos/${repo}/git/trees/${ref}?recursive=1&access_token=${token}`);
 	const contents = await response.json();
 	for (const item of contents.tree) {
 		if (item.type === 'blob' && item.path.startsWith(dir)) {


### PR DESCRIPTION
As they are both not required

Format:
```
{ 
  token: string, // default to '': disabled
  ref: string // default to 'master'
}
```

Based on my `feature/add-ref` branch.
This is a breaking change, I suggest you release #9 as minor and push this one as `v2.0.0`