### PR TITLE
Add option to return all the available info instead of just the path

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,15 +100,15 @@ Type: `string`
 
 A GitHub personal token, get one here: https://github.com/settings/tokens
 
-#### getDetails
+#### getFullData
 
 Type: `boolean`
 
 Default: `false`
 
-Only available in `viaTreesApi`.
+When set to `true`, an array of metadata objects is returned instead of an array of file paths. Note that the metadata objects of `viaTreesApi` and `viaContentsApi` are different.
 
-When set to `true`, returns an array of metadata objects instead of an array of file paths. See the [GitHub API docs](https://developer.github.com/v3/git/trees/#response) for an example of how this metadata is structured.
+Take a look at the docs for either the [Git Trees API](https://developer.github.com/v3/git/trees/#response) and the [Contents API](https://developer.github.com/v3/repos/contents/#response) to see how the respective metadata is structured.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -17,11 +17,27 @@ const listContent = require('list-github-dir-content');
 const myToken = '000'; // https://github.com/settings/tokens
 
 // They have the same output
-const filesArray = await listContent.viaTreesApi('Microsoft/vscode', 'src', myToken);
+const filesArray = await listContent.viaTreesApi({
+	user: 'microsoft',
+	repository: 'vscode',
+	directory: 'src',
+	token: myToken
+});
 // OR
-const filesArray = await listContent.viaContentsApi('Microsoft/vscode', 'src', myToken);
+const filesArray = await listContent.viaContentsApi({
+	user: 'microsoft',
+	repository: 'vscode',
+	directory: 'src',
+	token: myToken
+});
 // OR
-const filesArray = await listContent.viaContentsApi('Microsoft/vscode#master', 'src', myToken);
+const filesArray = await listContent.viaContentsApi({
+	user: 'microsoft',
+	repository: 'vscode',
+	ref: 'master',
+	directory: 'src',
+	token: myToken
+});
 
 // ['src/file.js', 'src/styles/main.css', ...]
 
@@ -34,8 +50,8 @@ if (filesArray.truncated) {
 
 ## API
 
-### listContent.viaTreesApi(identifier, directory, token)
-### listContent.viaContentsApi(identifier, directory, token)
+### listContent.viaTreesApi({ user, repository, ref = 'HEAD', directory, token, getDetails = false })
+### listContent.viaContentsApi({ user, repository, ref = 'HEAD', directory, token })
 
 Both methods return a Promise that resolves with an array of all the files in the chosen directory. They just vary in GitHub API method used. The paths will be relative to root (i.e. if `directory` is `dist/images`, the array will be `['dist/images/1.png', 'dist/images/2.png']`)
 
@@ -51,11 +67,25 @@ Known issues:
 - `viaTreesApi` is limited to around 60,000 files _per repo_
 
 
-#### identifier
+#### user
 
 Type: `string`
 
-`user/repo` or `user/repo#reference` combination, such as `Microsoft/vscode` or `Microsoft/vscode#master`. If the reference is omitted, the default branch will be used.
+GitHub user or organization, such as `microsoft`.
+
+#### repository
+
+Type: `string`
+
+The user's repository to read, like `vscode`.
+
+#### ref
+
+Type: `string`
+
+Default: `"HEAD"`
+
+The reference to use, for example a pointer (`"HEAD"`), a branch name (`"master"`) or a commit hash (`"71705e0"`).
 
 #### directory
 
@@ -68,6 +98,16 @@ The directory to download, like `docs` or `dist/images`
 Type: `string`
 
 A GitHub personal token, get one here: https://github.com/settings/tokens
+
+#### getDetails
+
+Type: `boolean`
+
+Default: `false`
+
+Only available in `viaTreesApi`.
+
+When set to `true`, returns an array of metadata objects instead of an array of file paths. See the [GitHub API docs](https://developer.github.com/v3/git/trees/#response) for an example of how this metadata is structured.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ if (filesArray.truncated) {
 
 ## API
 
-### listContent.viaTreesApi({ user, repository, ref = 'HEAD', directory, token, getDetails = false })
-### listContent.viaContentsApi({ user, repository, ref = 'HEAD', directory, token })
+### listContent.viaTreesApi(options)
+### listContent.viaContentsApi(options)
 
 Both methods return a Promise that resolves with an array of all the files in the chosen directory. They just vary in GitHub API method used. The paths will be relative to root (i.e. if `directory` is `dist/images`, the array will be `['dist/images/1.png', 'dist/images/2.png']`)
 
@@ -66,6 +66,7 @@ Known issues:
 - `viaContentsApi` is limited to 1000 files _per directory_
 - `viaTreesApi` is limited to around 60,000 files _per repo_
 
+The following properties are available on the `options` object: 
 
 #### user
 

--- a/index.js
+++ b/index.js
@@ -8,13 +8,19 @@ async function api(endpoint, token) {
 
 // Great for downloads with few sub directories on big repos
 // Cons: many requests if the repo has a lot of nested dirs
-async function viaContentsApi({user, repository, ref = 'HEAD', directory, token}) {
+async function viaContentsApi({
+	user,
+	repository,
+	ref = 'HEAD',
+	directory,
+	token
+}) {
 	const files = [];
 	const requests = [];
 	const contents = await api(`${user}/${repository}/contents/${directory}?ref=${ref}`, token);
 	for (const item of contents) {
 		if (item.type === 'file') {
-			files.push(item.path);
+			files.push(getDetails ? item : item.path);
 		} else if (item.type === 'dir') {
 			requests.push(viaContentsApi({
 				user,
@@ -32,7 +38,14 @@ async function viaContentsApi({user, repository, ref = 'HEAD', directory, token}
 // Great for downloads with many sub directories
 // Pros: one request + maybe doesn't require token
 // Cons: huge on huge repos + may be truncated
-async function viaTreesApi({user, repository, ref = 'HEAD', directory, token, getDetails = false}) {
+async function viaTreesApi({
+	user,
+	repository,
+	ref = 'HEAD',
+	directory,
+	token,
+	getDetails = false
+}) {
 	if (!directory.endsWith('/')) {
 		directory += '/';
 	}

--- a/index.js
+++ b/index.js
@@ -6,23 +6,23 @@ async function api(endpoint, token) {
 	return response.json();
 }
 
-function parseIdentifier(identifier) {
-	const [repo, ref = 'HEAD'] = identifier.split('#');
-	return {repo, ref};
-}
-
 // Great for downloads with few sub directories on big repos
 // Cons: many requests if the repo has a lot of nested dirs
-async function viaContentsApi(identifier, dir, token) {
+async function viaContentsApi({user, repository, ref = 'HEAD', directory, token}) {
 	const files = [];
 	const requests = [];
-	const {repo, ref} = parseIdentifier(identifier);
-	const contents = await api(`${repo}/contents/${dir}?ref=${ref}`, token);
+	const contents = await api(`${user}/${repository}/contents/${directory}?ref=${ref}`, token);
 	for (const item of contents) {
 		if (item.type === 'file') {
 			files.push(item.path);
 		} else if (item.type === 'dir') {
-			requests.push(viaContentsApi(repo, item.path, token));
+			requests.push(viaContentsApi({
+				user,
+				repository,
+				ref,
+				directory: item.path,
+				token
+			}));
 		}
 	}
 
@@ -32,17 +32,16 @@ async function viaContentsApi(identifier, dir, token) {
 // Great for downloads with many sub directories
 // Pros: one request + maybe doesn't require token
 // Cons: huge on huge repos + may be truncated
-async function viaTreesApi(identifier, dir, token) {
-	if (!dir.endsWith('/')) {
-		dir += '/';
+async function viaTreesApi({user, repository, ref = 'HEAD', directory, token, getDetails = false}) {
+	if (!directory.endsWith('/')) {
+		directory += '/';
 	}
 
 	const files = [];
-	const {repo, ref} = parseIdentifier(identifier);
-	const contents = await api(`${repo}/git/trees/${ref}?recursive=1`, token);
+	const contents = await api(`${user}/${repository}/git/trees/${ref}?recursive=1`, token);
 	for (const item of contents.tree) {
-		if (item.type === 'blob' && item.path.startsWith(dir)) {
-			files.push(item.path);
+		if (item.type === 'blob' && item.path.startsWith(directory)) {
+			files.push(getDetails ? item : item.path);
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -13,21 +13,23 @@ async function viaContentsApi({
 	repository,
 	ref = 'HEAD',
 	directory,
-	token
+	token,
+	getFullData = false
 }) {
 	const files = [];
 	const requests = [];
 	const contents = await api(`${user}/${repository}/contents/${directory}?ref=${ref}`, token);
 	for (const item of contents) {
 		if (item.type === 'file') {
-			files.push(getDetails ? item : item.path);
+			files.push(getFullData ? item : item.path);
 		} else if (item.type === 'dir') {
 			requests.push(viaContentsApi({
 				user,
 				repository,
 				ref,
 				directory: item.path,
-				token
+				token,
+				getFullData
 			}));
 		}
 	}
@@ -44,7 +46,7 @@ async function viaTreesApi({
 	ref = 'HEAD',
 	directory,
 	token,
-	getDetails = false
+	getFullData = false
 }) {
 	if (!directory.endsWith('/')) {
 		directory += '/';
@@ -54,7 +56,7 @@ async function viaTreesApi({
 	const contents = await api(`${user}/${repository}/git/trees/${ref}?recursive=1`, token);
 	for (const item of contents.tree) {
 		if (item.type === 'blob' && item.path.startsWith(directory)) {
-			files.push(getDetails ? item : item.path);
+			files.push(getFullData ? item : item.path);
 		}
 	}
 

--- a/tests.js
+++ b/tests.js
@@ -15,7 +15,7 @@ listContent
 		user: 'sindresorhus',
 		repository: 'refined-github',
 		directory: 'source/libs',
-		getDetails: true
+		getFullData: true
 	})
 	.then(data => console.log('\nviaTreesApi (detailed)\n', data));
 
@@ -26,3 +26,12 @@ listContent
 		directory: 'source/libs'
 	})
 	.then(data => console.log('\nviaContentsApi\n', data));
+
+listContent
+	.viaContentsApi({
+		user: 'sindresorhus',
+		repository: 'refined-github',
+		directory: 'source/libs',
+		getFullData: true
+	})
+	.then(data => console.log('\nviaContentsApi (detailed)\n', data));

--- a/tests.js
+++ b/tests.js
@@ -3,9 +3,26 @@
 const listContent = require('.');
 
 listContent
-	.viaTreesApi('sindresorhus/refined-github', 'source/libs')
+	.viaTreesApi({
+		user: 'sindresorhus',
+		repository: 'refined-github',
+		directory: 'source/libs'
+	})
 	.then(data => console.log('\nviaTreesApi\n', data));
 
 listContent
-	.viaContentsApi('sindresorhus/refined-github', 'source/libs')
+	.viaTreesApi({
+		user: 'sindresorhus',
+		repository: 'refined-github',
+		directory: 'source/libs',
+		getDetails: true
+	})
+	.then(data => console.log('\nviaTreesApi (detailed)\n', data));
+
+listContent
+	.viaContentsApi({
+		user: 'sindresorhus',
+		repository: 'refined-github',
+		directory: 'source/libs'
+	})
 	.then(data => console.log('\nviaContentsApi\n', data));


### PR DESCRIPTION
> This mainly exists to solve the needs of download-directory/download-directory.github.io#7.

This PR adds an option to return a list of metadata objects instead of bare file names in `viaTreesApi`. That new option is currently named `getDetails`, I [mentioned in a comment](https://github.com/download-directory/download-directory.github.io/issues/7#issuecomment-548120742) why I did not like some other ideas. Good name suggestions welcome!

The PR takes the opportunity to rewrite the signature to an object-based API (via [this comment](https://github.com/download-directory/download-directory.github.io/issues/7#issuecomment-548066257)).
