### PR TITLE
Add type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,16 +3,23 @@ interface ListGithubDirContentOptions {
 	repository: string
 	ref?: string
 	directory: string
-	token: string
+	token?: string
 	getFullData?: boolean
 }
 
-function ListGithubDirContent<ProvidedOptions extends ListGithubDirContentOptions>(options: ProvidedOptions):
-	ProvidedOptions['getFullData'] extends true ? Promise<any[]> : Promise<string[]>
-
-export = {
-	viaTreeApi: ListGithubDirContent,
-	viaTreesApi: ListGithubDirContent,
-	viaContentApi: ListGithubDirContent,
-	viaContentsApi: ListGithubDirContent
+interface TreeResult<T> extends Array<T> {
+	truncated: boolean
 }
+
+type ViaContentsApi = <ProvidedOptions extends ListGithubDirContentOptions>(options: ProvidedOptions) =>
+	ProvidedOptions['getFullData'] extends true ? Promise<any[]> : Promise<string[]>
+type ViaTreesApi = <ProvidedOptions extends ListGithubDirContentOptions>(options: ProvidedOptions) =>
+	ProvidedOptions['getFullData'] extends true ? Promise<TreeResult<any>> : Promise<TreeResult<string>>
+
+
+declare const listContent: {
+	viaTreesApi: ViaTreesApi,
+	viaContentsApi: ViaContentsApi
+}
+
+export = listContent

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,18 @@
+interface ListGithubDirContentOptions {
+	user: string
+	repository: string
+	ref?: string
+	directory: string
+	token: string
+	getFullData?: boolean
+}
+
+function ListGithubDirContent<ProvidedOptions extends ListGithubDirContentOptions>(options: ProvidedOptions):
+	ProvidedOptions['getFullData'] extends true ? Promise<any[]> : Promise<string[]>
+
+export = {
+	viaTreeApi: ListGithubDirContent,
+	viaTreesApi: ListGithubDirContent,
+	viaContentApi: ListGithubDirContent,
+	viaContentsApi: ListGithubDirContent
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-interface ListGithubDirContentOptions {
+interface ListGithubDirOptions {
 	user: string
 	repository: string
 	ref?: string
@@ -11,15 +11,12 @@ interface TreeResult<T> extends Array<T> {
 	truncated: boolean
 }
 
-type ViaContentsApi = <ProvidedOptions extends ListGithubDirContentOptions>(options: ProvidedOptions) =>
-	ProvidedOptions['getFullData'] extends true ? Promise<any[]> : Promise<string[]>
-type ViaTreesApi = <ProvidedOptions extends ListGithubDirContentOptions>(options: ProvidedOptions) =>
-	ProvidedOptions['getFullData'] extends true ? Promise<TreeResult<any>> : Promise<TreeResult<string>>
+export function viaContentsApi<T extends ListGithubDirOptions> (options: T):
+	T['getFullData'] extends true ?
+		Promise<any[]> :
+		Promise<string[]>;
 
-
-declare const listContent: {
-	viaTreesApi: ViaTreesApi,
-	viaContentsApi: ViaContentsApi
-}
-
-export = listContent
+export function viaTreesApi<T extends ListGithubDirOptions> (options: T):
+	T['getFullData'] extends true ?
+		Promise<TreeResult<any>> :
+		Promise<TreeResult<string>>;


### PR DESCRIPTION
More for completeness than anything else. 😁 

Btw we should have used the opportunity of the major version to drop the `viaTreeApi` and `viaContentApi` aliases. 😬