### PR TITLE
Use `Authorization` header instead of `access_token` URL parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@ const fetch = require('node-fetch'); // Automatically excluded in browser bundle
 
 async function api(endpoint, token) {
 	const response = await fetch(`https://api.github.com/repos/${endpoint}`, {
-		headers: {
+		headers: token ? {
 			Authorization: `Bearer ${token}`
-		}
+		} : undefined
 	});
 	return response.json();
 }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 const fetch = require('node-fetch'); // Automatically excluded in browser bundles
 
 async function api(endpoint, token) {
-	token = token ? `&access_token=${token}` : '';
-	const response = await fetch(`https://api.github.com/repos/${endpoint}${token}`);
+	const response = await fetch(`https://api.github.com/repos/${endpoint}`, {
+		headers: {
+			Authorization: `Bearer ${token}`
+		}
+	});
 	return response.json();
 }
 


### PR DESCRIPTION
Fix the issue from download-directory/download-directory.github.io#31 to switch from URL query parameters to Authorization HTTP header instead for the Github fetch call.